### PR TITLE
JsonResume as Yaml: Inspired from jsonresume.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,37 +10,11 @@ sass:
 
 # Resume settings
 resume_avatar:                  "true"
-resume_name:                    "Homer J. Simpson"
-resume_title:                   "Nuclear Safety Inspector"
-resume_contact_email:
-  "homerjsimpson@youremailaddress.com"
-
 # use "yes" to display the email contact button,
 # "no" to display an "I'm not looking for work" message,
 # or remove the resume_looking_for_work option entirely
 # to leave blank
 resume_looking_for_work:        "yes"
-
-# Decide which sections to use
-# comment out to hide (Experience is not shown
-# because it is the only required section)
-resume_section_education:       true
-resume_section_projects:        true
-resume_section_skills:          true
-resume_section_recognition:     true
-resume_section_links:           true
-resume_section_associations:    true
-
-# Resume social links
-# uncomment the options you wish to display, and add your own URL
-resume_social_links:
-  resume_github_url:            "https://github.com/jglovier/resume-template"
-  resume_twitter_url:           "http://twitter.com/jglovier"
-  resume_dribbble_url:          "https://dribbble.com/jag"
-  # resume_facebook_url:          "insert Facebook URL here"
-  resume_linkedin_url:          "https://www.linkedin.com/in/joelglovier"
-  # resume_instagram_url:         "insert your Instagram URL here"
-  resume_website_url:           "http://joelglovier.com"
 
 # Design settings
 resume_theme:                   default

--- a/_data/resume.yml
+++ b/_data/resume.yml
@@ -6,7 +6,10 @@
     email: "homerjsimpson@youremailaddress.com"
     phone: "(912) 555-4321"
     website: "https://en.wikipedia.org/wiki/Homer_Simpson"
-    summary: "This is the executive summary. You should write a few brief, concise, and meaningful sentences about yourself from a professional context, and your immediate career goals. Make the length appropriate for your needs, but K.I.S.S."
+    summary: |
+      This is the executive <a href='http://google.com'>summary</a>. <br>
+      You should write a few brief, concise, and meaningful sentences about yourself from a professional context, and your immediate career goals.<br>
+      Make the length appropriate for your needs, but <strong>K.I.S.S</strong>.
     location:
       address: "742 Evergreen Terrace"
       postalCode: "???"

--- a/_data/resume.yml
+++ b/_data/resume.yml
@@ -1,0 +1,134 @@
+---
+  basics:
+    name: "Homer J. Simpson"
+    label: "Nuclear Safety Inspector"
+    picture: "images/avatar.jpg"
+    email: "homerjsimpson@youremailaddress.com"
+    phone: "(912) 555-4321"
+    website: "https://en.wikipedia.org/wiki/Homer_Simpson"
+    summary: "This is the executive summary. You should write a few brief, concise, and meaningful sentences about yourself from a professional context, and your immediate career goals. Make the length appropriate for your needs, but K.I.S.S."
+    location:
+      address: "742 Evergreen Terrace"
+      postalCode: "???"
+      city: "Springfield"
+      countryCode: "US"
+      region: "??"
+    profiles:
+      -
+        network: "GitHub"
+        username: "jglovier"
+        url: "https://github.com/jglovier/resume-template"
+      -
+        network: "Twitter"
+        username: "jglovier"
+        url: "http://twitter.com/jglovier"
+      -
+        network: "Dribbble"
+        username: "jag"
+        url: "https://dribbble.com/jag"
+      -
+        network: "LinkedIn"
+        username: "joelglovier"
+        url: "https://www.linkedin.com/in/joelglovier"
+      -
+        network: "Website"
+        url: "http://joelglovier.com"
+  work:
+    -
+      company: "Springfield Nuclear Power Plant"
+      position: "Safety Inspector"
+      website: "http://company.com"
+      startDate: "Nov, 1980"
+      endDate: "Present"
+      summary: "Write about your core competencies in one or two sentences describing your position. If you held the position for a long time, it could be a longer section, including a couple bullet points:"
+      highlights:
+        - "Ate lots of donuts"
+        - "Fell asleep rarely"
+        - "Left promptly at end of day (sometimes earlier)"
+    -
+      company: "Sir Putt-A-Lot's Merrie Olde Fun Centre"
+      position: "Windmill Crank Operator"
+      website: "http://company.com"
+      startDate: "Jun, 1978"
+      endDate: "Sept, 1979"
+      summary: "If your stint was shorter, feel free to be brief and just call out the most meaningful points of your role. Be concise, and be meaninful. The person reading just needs enough to want to talk to you more about your experience."
+    -
+      company: "Simpson Lazer Tag"
+      position: "Windmill Crank Operator"
+      website: "http://company.com"
+      startDate: "Jun, 1978"
+      endDate: "Sept, 1979"
+      summary: "If your stint was shorter, feel free to be brief and just call out the most meaningful points of your role. Be concise, and be meaninful. The person reading just needs enough to want to talk to you more about your experience."
+  volunteer:
+    -
+      organization: "donutfinder.io"
+      position: "Founder & Primary Developer"
+      website: "http://organization.com/"
+      startDate: "2012"
+      endDate: "Present"
+      summary: "Donut Locator is an open source node/ember app that lets users find donuts within a defined radius from their home."
+      highlights:
+        - "Awarded 'Volunteer of the Month'"
+    -
+      organization: "Springfield Donut Eater's User Group"
+      position: "Co-Founder & Organizer "
+      website: "http://organization.com/"
+      startDate: "2012"
+      endDate: "Present"
+      summary: "DEUG is a local monthly meetup in Springfield where we share all the latest tips and tricks for dat donut lifestyle. I organize the group, and typically eat most of the donuts."
+  education:
+    -
+      institution: "Springfield College"
+      area: "Business Management"
+      studyType: "Associates Degree"
+      startDate: "2011-01-01"
+      endDate: "2013-01-01"
+      gpa: "4.0"
+      courses:
+        - "If you had any meaningful roles at college, feel free to write about them here."
+  awards:
+    -
+      title: "Outstanding Achievement"
+      date: "2010"
+      awarder: "Springfield Nuclear Power Plant"
+      summary: "Awarded for stopping a nuclear meltdown, even though I also started it."
+    -
+      title: "Duff Beer Customer of the year"
+      date: "1997 - 2001, 2003, 2008 - 2012"
+      awarder: "Duff Beer"
+      summary: "Honored by Duff Beer for being an outstanding customer several years straight. Qualifications included most beer consumed at a bar, most beer purchased, and most beer ralphed."
+    -
+      title: "Moe's Patron of the Month"
+      date: "12/2001, 8/2004"
+      awarder: "Moe"
+      summary: "Specifically this prestigious awarded twice for stopping a robber with my belly."
+  publications:
+    -
+      name: "Publication"
+      publisher: "Company"
+      releaseDate: "2014-10-01"
+      website: "http://publication.com"
+      summary: "Description..."
+  skills:
+    -
+      name: "Donut design"
+      level: "Sprinkle art, icing design, eclair management, taste testing, donut/coffee pairing research"
+    -
+      name: "Craft beer brewing"
+      level: "Hops inspection, brew testing, distribution management, bottle label design, festival and event management"
+    -
+      name: "Family leadership"
+      level: "Bread winning, conflict resolution, couch inspection, TV longevity testing"
+  languages:
+    -
+      language: "English"
+      fluency: "Native speaker"
+  interests:
+    -
+      name: "Beeeeeeer"
+      keywords:
+        - "Beer"
+  references:
+    -
+      name: "Jane Doe"
+      reference: "Reference..."

--- a/_includes/icon-links.html
+++ b/_includes/icon-links.html
@@ -1,41 +1,50 @@
-<!-- annnd guess where these are defined? Yup, you guessed it: the _config.yml file -->
-{% if site.resume_social_links %}
 <ul class="icon-links">
 
-  <!-- GitHub link -->
-  {% if site.resume_social_links.resume_github_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_github_url }}" class="icon-link">{% include icons/icon-github.html %}</a></li>
-  {% endif %}
+  {% for entry in site.data.resume.basics.profiles %}
+  <li class="icon-link-item"><a href="{{ entry.url }}" class="icon-link">
+    {% if entry.network == "GitHub" %}
 
-  <!-- Twitter link -->
-  {% if site.resume_social_links.resume_twitter_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_twitter_url }}" class="icon-link">{% include icons/icon-twitter.html %}</a></li>
-  {% endif %}
+      {% include icons/icon-github.html %}
 
-  <!-- Dribbble link -->
-  {% if site.resume_social_links.resume_dribbble_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_dribbble_url }}" class="icon-link">{% include icons/icon-dribbble.html %}</a></li>
-  {% endif %}
+    {% endif %}
 
-  <!-- Facebook link -->
-  {% if site.resume_social_links.resume_facebook_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_facebook_url }}" class="icon-link">{% include icons/icon-facebook.html %}</a></li>
-  {% endif %}
+    {% if entry.network == "Twitter" %}
 
-  <!-- LinkedIn link -->
-  {% if site.resume_social_links.resume_linkedin_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_linkedin_url }}" class="icon-link">{% include icons/icon-linkedin.html %}</a></li>
-  {% endif %}
+      {% include icons/icon-twitter.html %}
 
-  <!-- Instagram link -->
-  {% if site.resume_social_links.resume_instagram_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_instagram_url }}" class="icon-link">{% include icons/icon-instagram.html %}</a></li>
-  {% endif %}
+    {% endif %}
 
-  <!-- Website link -->
-  {% if site.resume_social_links.resume_website_url %}
-  <li class="icon-link-item"><a href="{{ site.resume_social_links.resume_website_url }}" class="icon-link">{% include icons/icon-website.html %}</a></li>
-  {% endif %}
+    {% if entry.network == "Dribbble" %}
+
+      {% include icons/icon-dribbble.html %}
+
+    {% endif %}
+
+    {% if entry.network == "Facebook" %}
+
+      {% include icons/icon-facebook.html %}
+
+    {% endif %}
+
+    {% if entry.network == "LinkedIn" %}
+
+      {% include icons/icon-linkedin.html %}
+
+    {% endif %}
+
+    {% if entry.network == "Instagram" %}
+
+      {% include icons/icon-instagram.html %}
+
+    {% endif %}
+
+    {% if entry.network == "Website" %}
+
+      {% include icons/icon-website.html %}
+
+    {% endif %}
+  </a></li>
+
+  {% endfor %}
 
 </ul>
-{% endif %}

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -11,27 +11,25 @@
 
         <!-- You can turn off the avatar in _config.yml by setting to false -->
         {% if site.resume_avatar == 'true' %}
-        <img src="images/avatar.jpg" alt="my photo" class="avatar">
+        <img src="{{ site.data.resume.basics.picture }}" alt="my photo" class="avatar">
         {% endif %}
 
-        <!-- Your name is defined in the _config.yml file -->
-        <h1 class="header-name">{{ site.resume_name }}</h1>
+        <h1 class="header-name">{{ site.data.resume.basics.name }}</h1>
 
         <div class="title-bar">
 
-          <!-- Your title is also defined in the _config.yml file -->
-          <h2 class="header-title">{{ site.resume_title }}</h2>
+          <h2 class="header-title">{{ site.data.resume.basics.label }}</h2>
 
           <!-- This is the markup for the icon links; moved out to an include because it's very verbose, and you shouldn't ever need to edit the markup (unless you want to re-order the icons); if you want to customize which links appear, define them in the _config.yml file -->
           {% include icon-links.html %}
         </div>
 
         <div class="executive-summary">
-          <p>This is the executive summary. You should write a few brief, concise, and meaningful sentences about yourself from a professional context, and your immediate career goals. Make the length appropriate for your needs, but K.I.S.S.</p>
+          <p>{{ site.data.resume.basics.summary }}</p>
         </div>
 
         {% if site.resume_looking_for_work == 'yes' %}
-        <a href="mailto:{{ site.resume_contact_email }}" class="contact-button">Contact me</a>
+        <a href="mailto:{{ site.data.resume.basics.email }}" class="contact-button">Contact me</a>
         {% elsif site.resume_looking_for_work == 'no' %}
         <a class="contact-button not-looking">I'm not looking for work right now.</a>
         {% else %}
@@ -46,56 +44,47 @@
           <h2>Experience</h2>
         </header>
 
-        <!-- Duplicate these resume-item elements and edit accordingly for each job you want to add here -->
+        {% for entry in site.data.resume.work %}
         <div class="resume-item">
-          <h3 class="resume-item-title">Springfield Nuclear Power Plant</h3>
-          <h4 class="resume-item-details">Safety Inspector &bull; Nov, 1980 &mdash; Present</h4>
-          <p class="resume-item-copy">Write about your core competencies in one or two sentences describing your position. If you held the position for a long time, it could be a longer section, including a couple bullet points:</p>
+          <h3 class="resume-item-title">{{ entry.company }}</h3>
+          <h4 class="resume-item-details">{{ entry.position }} &bull; {{ entry.startDate }} &mdash; {{ entry.endDate }}</h4>
+          <p class="resume-item-copy">{{ entry.summary }}</p>
+
           <ul class="resume-item-list">
-            <li>Ate lots of donuts</li>
-            <li>Fell asleep rarely</li>
-            <li>Left promptly at end of day (sometimes earlier)</li>
+            {% for highlight in entry.highlights %}
+            <li>{{ highlight }}</li>
+            {% endfor %}
           </ul>
-          <p class="resume-item-copy">If you're going to copy paste markup, or edit it, just be sure to keep the appropriate classnames on your new elements for styling purposes.</p>
+        </div>
 
-        </div><!-- end of resume-item -->
-
-        <!-- another resume item -->
-        <div class="resume-item">
-          <h3 class="resume-item-title">Sir Putt-A-Lot's Merrie Olde Fun Centre</h3>
-          <h4 class="resume-item-details">Windmill Crank Operator &bull; Jun, 1978 &mdash; Sept, 1979</h4>
-          <p class="resume-item-copy">If your stint was shorter, feel free to be brief and just call out the most meaningful points of your role. Be concise, and be meaninful. The person reading just needs enough to want to talk to you more about your experience.</p>
-
-        </div><!-- end of resume-item -->
-
-        <!-- by now you're getting the picture... -->
-        <div class="resume-item">
-          <h3 class="resume-item-title">Simpson Lazer Tag</h3>
-          <h4 class="resume-item-details">Front Desk Attendant &bull; Jun, 1975 &mdash; May, 1978</h4>
-          <p class="resume-item-copy">Boy, when Marge first told me she was going to the Police Academy, I thought it would be fun and exciting, you know, like the movie... Spaceballs. But instead, it's been painful and disturbing, like the movie Police Academy.</p>
-
-        </div><!-- end of resume-item -->
-
+        {% endfor %}
       </section>
       <!-- end Experience -->
 
-      {% if site.resume_section_education %}
       <!-- begin Education -->
+
+      <!-- begin Experience -->
       <section class="content-section">
 
         <header class="section-header">
           <h2>Education</h2>
         </header>
 
+        {% for entry in site.data.resume.education %}
         <div class="resume-item">
-          <h3 class="resume-item-title">Springfield College</h3>
-          <h4 class="resume-item-details">Associates Degree, Business Management &bull; 1984 &mdash; 1986</h4>
-          <p class="resume-item-copy">If you had any meaningful roles at college, feel free to write about them here.</p>
+          <h3 class="resume-item-title">{{ entry.institution }}</h3>
+          <h4 class="resume-item-details">{{ entry.studyType }}, {{ entry.area }} &bull; {{ entry.startDate }} &mdash; {{ entry.endDate }}</h4>
+
+          <ul class="resume-item-list">
+            {% for course in entry.courses %}
+            <li>{{ course }}</li>
+            {% endfor %}
+          </ul>
         </div>
 
+        {% endfor %}
       </section>
       <!-- end Education -->
-      {% endif %}
 
       {% if site.resume_section_projects %}
       <!-- begin Projects -->
@@ -105,17 +94,15 @@
           <h2>Projects</h2>
         </header>
 
+        {% for entry in site.data.resume.volunteer %}
         <div class="resume-item">
-          <h3 class="resume-item-title"><a href="http://donutlocator.io">donutfinder.io</a></h3>
-          <h4 class="resume-item-details">Founder & Primary Developer &bull; 2012 &mdash; Present</h4>
-          <p class="resume-item-copy">Donut Locator is an open source node/ember app that lets users find donuts within a defined radius from their home.</p>
+          <h3 class="resume-item-title">{{ entry.organization }}</h3>
+          <h4 class="resume-item-details">{{ entry.position }} &bull; {{ entry.startDate }} &mdash; {{ entry.endDate }}</h4>
+          <p class="resume-item-copy">{{ entry.summary }}</p>
+
         </div>
 
-        <div class="resume-item">
-          <h3 class="resume-item-title">Springfield Donut Eater's User Group</h3>
-          <h4 class="resume-item-details">Co-Founder & Organizer &bull; 2007 &mdash; Present</h4>
-          <p class="resume-item-copy">DEUG is a local monthly meetup in Springfield where we share all the latest tips and tricks for dat donut lifestyle. I organize the group, and typically eat most of the donuts.</p>
-        </div>
+        {% endfor %}
 
       </section>
       <!-- end Projects -->
@@ -129,20 +116,12 @@
           <h2>Skills</h2>
         </header>
 
+        {% for entry in site.data.resume.skills %}
         <div class="resume-item">
-          <h4 class="resume-item-details">Donut design</h4>
-          <p class="resume-item-copy">Sprinkle art, icing design, eclair management, taste testing, donut/coffee pairing research</p>
+          <h3 class="resume-item-title">{{ entry.name }}</h3>
+          <h4 class="resume-item-details">{{ entry.level }}</h4>
         </div>
-
-        <div class="resume-item">
-          <h4 class="resume-item-details">Craft beer brewing</h4>
-          <p class="resume-item-copy">Hops inspection, brew testing, distribution management, bottle label design, festival and event management</p>
-        </div>
-
-        <div class="resume-item">
-          <h4 class="resume-item-details">Family leadership</h4>
-          <p class="resume-item-copy">Bread winning, conflict resolution, couch inspection, TV longevity testing</p>
-        </div>
+        {% endfor %}
 
       </section>
       <!-- end Skills -->
@@ -156,69 +135,16 @@
           <h2>Recognition</h2>
         </header>
 
+        {% for entry in site.data.resume.awards %}
         <div class="resume-item">
-          <h3 class="resume-item-title">Springfield Nuclear Power Plant</h3>
-          <h4 class="resume-item-details">Outstanding Achievement &bull; 2010</h4>
-          <p class="resume-item-copy">Awarded for stopping a nuclear meltdown, even though I also started it.</p>
+          <h3 class="resume-item-title">{{ entry.awarder }}</h3>
+          <h4 class="resume-item-details">{{ entry.title }} &bull; {{ entry.date }}</h4>
+          <p class="resume-item-copy">{{ entry.summary }}</p>
         </div>
-
-        <div class="resume-item">
-          <h3 class="resume-item-title">Duff Beer Customer of the year</h3>
-          <h4 class="resume-item-details">1997 &mdash; 2001, 2003, 2008 &mdash; 2012</h4>
-          <p class="resume-item-copy">Honored by <a href="https://en.wikipedia.org/wiki/Duff_Beer">Duff Beer</a> for being an outstanding customer several years straight. Qualifications included most beer consumed at a bar, most beer purchased, and most beer ralphed.</p>
-        </div>
-
-        <div class="resume-item">
-          <h3 class="resume-item-title">Moe's Patron of the Month</h3>
-          <h4 class="resume-item-details">12/2001, 8/2004</h4>
-          <p class="resume-item-copy">Specifically this prestigious awarded twice for stopping a robber with my belly.</p>
-        </div>
+        {% endfor %}
 
       </section>
       <!-- end Recognition -->
-      {% endif %}
-
-      {% if site.resume_section_associations %}
-      <!-- begin Associations -->
-      <section class="content-section">
-
-        <header class="section-header">
-          <h2>Associations</h2>
-        </header>
-
-        <div class="resume-item">
-          <h3 class="resume-item-title"><a href="http://beerfortheworld.com">Beer for the World</a></h3>
-          <h4 class="resume-item-details">Volunteer &bull; 2008 &mdash; Present</h4>
-          <p class="resume-item-copy">Organized fund drives and participated in fundraising events for the benefit of families in third world countries without proper access to malt beverages.</p>
-        </div>
-
-        <div class="resume-item">
-          <h3 class="resume-item-title">Springfield Nuclear Workers Labor Union</h3>
-          <h4 class="resume-item-details">Member in Good Standin &bull; 1994 &mdash; Present</h4>
-          <p class="resume-item-copy">Founding member of the local nuclear workers labor union.</p>
-        </div>
-
-      </section>
-      <!-- end Recognition -->
-      {% endif %}
-
-      {% if site.resume_section_links %}
-      <!-- begin Links -->
-      <section class="content-section">
-
-        <header class="section-header">
-          <h2>Additional Links</h2>
-        </header>
-
-        <div class="resume-item">
-          <ul class="resume-item-list">
-            <li><a href="#">Springfield Poker Club</a></li>
-            <li><a href="#">Springfield Donut Eater's User Group</a></li>
-          </ul>
-        </div>
-
-      </section>
-      <!-- end Links -->
       {% endif %}
 
       <footer class="page-footer">


### PR DESCRIPTION
As mentioned on twitter: Jekyll/GH Pages are a perfect fit for a resume and a while ago I discovered https://jsonresume.org/, but JSON is not an ideal solution for Jekyll.

So I converted the json demo data to yaml and took the data from your template. Unfortunatly not all fields are in the jsonresume spec (and the spec seems frozen at version 0.0.0.0... mh... ) but I guess you see the idea behind it.

The benefit of this approach: Everything is in one yaml file and the template could easily be changed.
