### PR TITLE
Changed CollegeOrUniversity item prop from worksFor to alumniOf

### DIFF
--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -89,7 +89,7 @@
           <h2>Education</h2>
         </header>
 
-        <div class="resume-item" itemscope itemprop="worksFor" itemtype="http://schema.org/CollegeOrUniversity">
+        <div class="resume-item" itemscope itemprop="alumniOf" itemtype="http://schema.org/CollegeOrUniversity">
           <h3 class="resume-item-title" itemprop="name">Springfield College</h3>
           <h4 class="resume-item-details" itemprop="description">Associates Degree, Business Management &bull; 1984 &mdash; 1986</h4>
           <p class="resume-item-copy">If you had any meaningful roles at college, feel free to write about them here.</p>


### PR DESCRIPTION
I believe the itemprop for CollegeOrUniversity should be `alumniOf` rather that `worksFor`, since this is the Education section of the resume (it would make sense under the Experience section).

I'm following the third example [here](http://schema.org/EducationalOrganization):

``` html
<div itemscope itemtype="http://schema.org/Person">
  <span itemprop="name">Delia Derbyshire</span>
  <link itemprop="sameAs" href="http://en.wikipedia.org/wiki/Delia_Derbyshire"/>
  <div itemprop="alumniOf" itemscope
        itemtype="http://schema.org/OrganizationRole">
    <div itemprop="alumniOf" itemscope
            itemtype="http://schema.org/CollegeOrUniversity">
      <span itemprop="name">University of Cambridge</span>
      <link itemprop="sameAs" href="http://en.wikipedia.org/wiki/University_of_Cambridge"/>
    </div>
    <span itemprop="startDate">1959</span>
</div>
```
