### PR TITLE
Removed hardcoded URLs from Associations section in resume layout. 

### DIFF
--- a/_data/associations.yml
+++ b/_data/associations.yml
@@ -1,11 +1,15 @@
 # Associations
+# comment out the urls if you do not wish to display them
+
 - organization: Beer for the World
   role: Volunteer
   year: 2008 &mdash; Present
+  url: http://beerfortheworld.com
   summary: Organized fund drives and participated in fundraising events for the benefit of families in third world countries without proper access to malt beverages.
 
 
 - organization: Springfield Nuclear Workers Labor Union
-  role: Member in Good Standin
+  role: Member in Good Standing
   year: 1994 &mdash; Present
+  url: http://snwlu.org
   summary: Founding member of the local nuclear workers labor union.

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,12 +1,16 @@
 # Projects
+# uncomment the urls if you wish to display them, and add your own URL
+
 # donutfinder.io
 - project: donutfinder.io
   role: Founder & Primary Developer
   duration: 2012 &mdash; Present
+  # url: "#"
   description: Donut Locator is an open source node/ember app that lets users find donuts within a defined radius from their home.
 
 #Springfield Donut Eater's User Group
 - project: Springfield Donut Eater's User Group
   role: Co-Founder & Organizer
   duration: 2007 &mdash; Present
+  # url: "#"
   description: DEUG is a local monthly meetup in Springfield where we share all the latest tips and tricks for dat donut lifestyle. I organize the group, and typically eat most of the donuts.

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -94,7 +94,7 @@
 
         {% for project in site.data.projects %}
         <div class="resume-item" itemscope itemprop="worksFor" itemtype="http://schema.org/Organization">
-          <h3 class="resume-item-title" itemprop="name">{{ project.project }}</h3>
+          <h3 class="resume-item-title" itemprop="name">{% if project.url %}<a href="{{ project.url }}">{{ project.project }}</a>% else %}{{ project.project }}{% endif %}</h3>
           <h4 class="resume-item-details" itemprop="description">{{ project.role }}  &bull; {{ project.duration }}</h4>
           <p class="resume-item-copy">{{ project.description }}</p>
         </div>
@@ -152,7 +152,7 @@
 
         {% for association in site.data.associations %}
         <div class="resume-item">
-          <h3 class="resume-item-title"><a href="http://beerfortheworld.com">{{ association.organization }}</a></h3>
+          <h3 class="resume-item-title">{% if association.url %}<a href="{{ association.url }}">{{ association.organization }}</a>{% else %}{{ association.organization }}{% endif %}</h3>
           <h4 class="resume-item-details">{{ association.role }} &bull; {{ association.year }}</h4>
           <p class="resume-item-copy">{{ association.summary }}</p>
         </div>


### PR DESCRIPTION
This commit removes the hardcoded URLs in the resume layout. The URLs are instead moved to the Associations data. In addition, the URLs are made optional and can be commented out.

This commit also adds the same logic to the Projects data.