### PR TITLE
Fix/title spacing ie11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'github-pages'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem 'github-pages'
+# this gem provides regeneration support improvements on Windows
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    ffi (1.9.18-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (150)
@@ -167,6 +168,8 @@ GEM
     net-dns (0.8.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.0-x64-mingw32)
+      mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -193,12 +196,15 @@ GEM
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
+    wdm (0.1.1)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.14.3
+   1.16.0

--- a/_sass/_resume.scss
+++ b/_sass/_resume.scss
@@ -101,6 +101,10 @@
       @include transition(all .2s ease);
     }
   }
+
+  .icon {
+    height: 28px;
+  }
 }
 
 .contact-button {


### PR DESCRIPTION
This should address #13.

- ab237c3 adds gem 'wdm', '>= 0.1.0' if Gem.win_platform? to Gemfile
    this is the recommended for windows from https://jekyllrb.com/docs/windows/
- 38959e9 corrects spacing issue with svg icon height
    the svg .icon were not being constrained to their actual height for some reason, I just set it as a wrote value

Screenshot of it working as expected in IE11.
![image](https://user-images.githubusercontent.com/622118/33490445-ce2a4ce2-d67c-11e7-9c18-1afab933e86f.png)
