### PR TITLE
fix award-title below resume-item-details in print mode

### DIFF
--- a/_sass/_resume.scss
+++ b/_sass/_resume.scss
@@ -221,9 +221,13 @@
 
     .resume-item-details {
       font-size: 12px;
-      margin: 0;
+      margin: 0 0 .75rem;
       line-height: .7em;
       font-style:italic;
+
+      &.award-title {
+        font-size: 11px;
+      }
     }
   }
 }


### PR DESCRIPTION
I've found this when I was about to save the resume as pdf. Hope this helps.