### PR TITLE
Add iteration through multiple awards for education.  

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -6,3 +6,9 @@
     - award: Quickest to fall asleep
     - award: Fastest donut eater
   summary: If you had any meaningful roles at college, feel free to write about them here
+
+- degree: High School Diploma
+  uni: Springfield High
+  year: 1984
+  award: Least likely to graduate College
+  summary: You can choose to have either a single or multiple awards

--- a/_data/education.yml
+++ b/_data/education.yml
@@ -2,5 +2,7 @@
 - degree: Associates Degree, Business Management
   uni: Springfield College
   year: 1984 &mdash; 1986
-  awards: Quickest to fall asleep
+  awards:
+    - award: Quickest to fall asleep
+    - award: Fastest donut eater
   summary: If you had any meaningful roles at college, feel free to write about them here

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -78,7 +78,16 @@
         <div class="resume-item" itemscope itemprop="alumniOf" itemtype="http://schema.org/CollegeOrUniversity">
           <h3 class="resume-item-title" itemprop="name">{{ education.uni }}</h3>
           <h4 class="resume-item-details group" itemprop="description">{{ education.degree }} &bull; {{ education.year }}</h4>
-          <h5 class="resume-item-details award-title" itemprop="description">{{ education.awards }}</h5>
+          <!-- <h5 class="resume-item-details award-title" itemprop="description">{{ education.awards }}</h5>
+          <h5 class="resume-item-details award-title" itemprop="description">{{ education.awards2 }}</h5> -->
+          <p class="resume-item-copy" itemprop="description">
+            <ul class="resume-item-list">
+              {% for award in education.awards %}
+              <li>{{ award.award }}</li>
+              {% endfor %}
+            </ul></h5>
+
+
           <p class="resume-item-copy">{{ education.summary }}</p>
         </div>
         {% endfor %}

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -78,8 +78,7 @@
         <div class="resume-item" itemscope itemprop="alumniOf" itemtype="http://schema.org/CollegeOrUniversity">
           <h3 class="resume-item-title" itemprop="name">{{ education.uni }}</h3>
           <h4 class="resume-item-details group" itemprop="description">{{ education.degree }} &bull; {{ education.year }}</h4>
-          <!-- <h5 class="resume-item-details award-title" itemprop="description">{{ education.awards }}</h5>
-          <h5 class="resume-item-details award-title" itemprop="description">{{ education.awards2 }}</h5> -->
+          <h5 class="resume-item-details award-title" itemprop="description">{{ education.award }}</h5>
           <p class="resume-item-copy" itemprop="description">
             <ul class="resume-item-list">
               {% for award in education.awards %}


### PR DESCRIPTION
(Note, this is my first ever fork/pull request...I hope I did it right and it's useful!)

This allows multiple bulleted “award” entries to be present in the “Awards” item, for those with multiple entries.  Also adds the ability to have a base-level "Award" entry for scenarios when only one award is necessary.

Added example content to demonstrate both methods.

Alternative methods of accomplishing this (such as `<ul>`) did not render well to a PDF.