### PR TITLE
Use relative favicon url to allow non-empty baseurl

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,5 +14,5 @@
 
   <link rel="stylesheet" href="css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="icon" type="image/x-icon" href="/favicon.png" />
+  <link rel="icon" type="image/x-icon" href="favicon.png" />
 </head>


### PR DESCRIPTION
This PR makes the favicon url relative which allows empty and non-empty baseurl settings.