### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gem 'github-pages'
 # this gem provides regeneration support improvements on Windows
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'rexml'
+gem 'webrick'


### PR DESCRIPTION
More recent versions of Ruby do not include `rexml` and `webrick`, which Jekyll requires.