### PR TITLE
Add optional location and sort fields for experience entries

### DIFF
--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -1,12 +1,17 @@
 # Jobs
 # VP of Global Communications
 - company: Springfield International Human Rights Outreach
+  sort_start: 201310
+  sort_end: 999912
   position: VP of Global Communications
   duration: Oct, 2013 &mdash; Present
+  location: Springfield, USA
   summary: Write about your core competencies in one or two sentences describing your position. If you held the position for a long time, it could be a longer section, including a couple bullet points	<ul class="resume-item-list"><li>A project you are proud of</li><li>Another awesome project</li><li>or a team or department you worked with</li></ul>
 
 # Director of Digital Stratgy
 - company: United Nations Human Rights Council
+  sort_start: 201006
+  sort_end: 201309
   position: Director of Digital Strategy
   duration:  Jun, 2010 &mdash; Sept, 2013
   summary: If your stint was shorter, feel free to be brief and just call out the most meaningful points of your role. Be concise, and be meaninful. The person reading just needs enough to want to talk to you more about your experience.
@@ -14,6 +19,8 @@
 
 # Communications Coordinator
 - company: Springfield Women & Children's Center
+  sort_start: 200806
+  sort_end: 201005
   position: Communications Coordinator
   duration:   Jun, 2008  &mdash; May, 2010
   summary: Led communication efforts across digital and traditional media channels for marketing and public relations, internal communication strategies, and coordinated support programs for the recipients of the center's services.

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -56,10 +56,20 @@
           <h2>Experience</h2>
         </header>
 
-        {% for job in site.data.experience %}
+        {% assign jobs = site.data.experience %}
+        {% assign jobs_with_sort = jobs | where_exp: "job", "job.sort_start" %}
+        {% if jobs_with_sort.size == jobs.size %}
+          {% assign last_jobs = jobs | where_exp: "job", "job.sort_last == true" %}
+          {% assign regular_jobs = jobs | where_exp: "job", "job.sort_last != true" %}
+          {% assign present_jobs = regular_jobs | where_exp: "job", "job.sort_end >= 999912" | sort: 'sort_start' | reverse %}
+          {% assign past_jobs = regular_jobs | where_exp: "job", "job.sort_end < 999912" | sort: 'sort_end' %}
+          {% assign past_jobs = past_jobs | sort: 'sort_start' | reverse %}
+          {% assign jobs = present_jobs | concat: past_jobs | concat: last_jobs %}
+        {% endif %}
+        {% for job in jobs %}
         <div class="resume-item" itemscope itemprop="worksFor" itemtype="http://schema.org/Organization">
           <h3 class="resume-item-title" itemprop="name">{{ job.company }}</h3>
-          <h4 class="resume-item-details" itemprop="description">{{ job.position }} &bull; {{ job.duration }}</h4>
+          <h4 class="resume-item-details" itemprop="description">{{ job.position }} &bull; {{ job.duration }}{% if job.location and job.location != "" %} &bull; {{ job.location }}{% endif %}</h4>
           <p class="resume-item-copy">{{ job.summary }}</p>
         </div><!-- end of resume-item -->
         {% endfor %}


### PR DESCRIPTION
## Summary
- Display an optional `location` field in the experience header line (`Position • Duration • Location`)
- Add optional `sort_start` / `sort_end` (YYYYMM) sorting so present roles (`sort_end: 999912`) appear first and past roles sort by most recent start date
- Support optional `sort_last: true` to pin specific entries to the bottom of the experience section
- Fall back to YAML file order when sort fields are omitted, keeping existing resumes backward compatible

## Sample data
Updates the demo `_data/experience.yml` with example `sort_start` / `sort_end` values and a sample `location` on the present role.

## Test plan
- [ ] Build site with updated sample data and confirm present role appears first
- [ ] Confirm location renders in the job header when set
- [ ] Confirm resumes without sort fields still render in YAML file order
- [ ] Confirm `sort_last: true` entries appear at the bottom when sorting is enabled


Made with [Cursor](https://cursor.com)